### PR TITLE
Added support for setting charset for request body encoding.

### DIFF
--- a/RestGrailsPlugin.groovy
+++ b/RestGrailsPlugin.groovy
@@ -133,7 +133,7 @@ class RestGrailsPlugin {
 			client = klass.newInstance()
 			if (params.uri) client.uri = params.remove("uri")
 			if (params.contentType) client.contentType = params.remove("contentType")
-
+			if (params.charset) client.getEncoder().setCharset(params.remove("charset"))
 		} catch (IllegalArgumentException e) {
 			throw new RuntimeException("Failed to create ${(klass == HTTPBuilder ? 'http' : 'rest')} client reason: $e", e)
 		} catch (InvocationTargetException e) {


### PR DESCRIPTION
I added support to explicitly set the charset to encode the request body. The need for this occurred on a system with system default encoding != UTF-8 where REST calls should nevertheless be made UTF-8 encoded. So far there seems to be no convenient way to influence the request body encoding.
