### PR TITLE
Added support for a ignoreSSLIssues as a parameter on dynamic methods

### DIFF
--- a/RestGrailsPlugin.groovy
+++ b/RestGrailsPlugin.groovy
@@ -96,6 +96,7 @@ class RestGrailsPlugin {
 
 	private makeClient(Class klass, Map params, application) {
 		def client
+                def ignoreSSLIssues = (params.ignoreSSLIssues)?params.remove("ignoreSSLIssues"):false
 		if (klass == AsyncHTTPBuilder) {
 			client = makeAsyncClient(klass, params)
 
@@ -104,7 +105,7 @@ class RestGrailsPlugin {
 		}
 
 		if (HTTPBuilderSSLConstants.HTTPS == client.uri.toURL().protocol) {
-			addSSLSupport(client, application)
+			(ignoreSSLIssues)?client.ignoreSSLIssues():addSSLSupport(client, application)
 		}
 
 		return client


### PR DESCRIPTION
Allows the use of this as a parameter on dynamic methods using to the underlying http-builder support for it. Essentially it alternatively registers a scheme using the ignoreSSLIssues() function on the client rather than via SimpleHTTPBuilderSSLHelper.groovy

This addresses closed issue #14 where the http-builder was updated but the plugin had no handling for it (example in the comments)
